### PR TITLE
Show “ago” instead of “in” for any negative diff

### DIFF
--- a/lib/src/simple_moment_base.dart
+++ b/lib/src/simple_moment_base.dart
@@ -48,7 +48,7 @@ class Moment {
     else timeString = "${diff.inDays.abs() ~/ 356} years";
 
     if (!withoutPrefixOrSuffix) {
-      if (diff.inSeconds < 0)
+      if (diff.isNegative)
         timeString += " ago";
       else
         timeString = "in " + timeString;

--- a/test/simple_moment_test.dart
+++ b/test/simple_moment_test.dart
@@ -32,5 +32,10 @@ void main() {
       DateTime compareDate = DateTime.parse("2016-12-31 11:59:30");
       expect(new Moment.fromDate(currentDate).from(compareDate) == "a few seconds ago", isTrue);
     });
+
+    test('Moment.from(less than a second ago)', () {
+      DateTime compareDate = DateTime.parse("2016-12-31 11:59:59.001");
+      expect(new Moment.fromDate(currentDate).from(compareDate) == "a few seconds ago", isTrue);
+    });
   });
 }


### PR DESCRIPTION
Thanks for publishing this library! I ran into a problem when comparing dates that were < 1 second apart. This fix seems to do the trick.