### PR TITLE
:arrow_up: (sdk) Upgrade to Dart 2.0.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Files and directories created by pub
 .packages
 .pub/
+.dart_tool/
 build/
 packages
 # Remove the following pattern if you wish to check in your lock file

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ author: rinukkusu <rinukkusu@auen.land>
 homepage: https://github.com/rinukkusu
 
 environment:
-  sdk: '>=1.0.0 <2.0.0'
+  sdk: '>=2.0.0 <3.0.0'
 
 dev_dependencies:
-  test: '>=0.12.0 <0.13.0'
+  test: ^1.3.0


### PR DESCRIPTION
Hi there!, 
the latest version of `simple_moment` can't be added as a package to dart 2 (stable) apps.
I've made a few changes
 - upgrade sdk constraint
 - upgrade test package
 - gitignore .dart_tool

All tests are passing

Since this will be a breaking change for current users of `simple_moment`, I did not bump version number, thinking it's best left for the author to decide.

Cheers!